### PR TITLE
Fix setup instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ repository forms an effort to come up with more advanced rulesets than there cur
 ### Usage
 To install this package, go to your Magento 2 root and use the following:
 
-    composer config repositories:extdn-phpcs vcs git@github.com:extdn/extdn-phpcs.git
+    composer config repositories.extdn-phpcs vcs git@github.com:extdn/extdn-phpcs.git
     composer require extdn/phpcs:dev-master
 
 Once installed, you can run PHPCS from the command-line to analyse your code `XYZ`:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ templates, not using `setTemplate` in Blocks and using namespaced classes for Vi
 repository forms an effort to come up with more advanced rulesets than there currently are.
 
 ### Usage
+
 To install this package, go to your Magento 2 root and use the following:
 
     composer config repositories.extdn-phpcs vcs git@github.com:extdn/extdn-phpcs.git
@@ -24,6 +25,7 @@ Once installed, you can run PHPCS from the command-line to analyse your code `XY
     vendor/bin/phpcs --standard=./vendor/extdn/phpcs/Extdn vendor/XYZ
 
 ### Contributions
+
 Any contributions are welcome. Add a new issue under **Issues** to address new rulesets that are needed or report other issues.
 
 As an example, you can use the `SetTemplateInBlockSniff` within the folder `Extdn/Sniffs/Blocks`. It can be tested upon a sample file under `Extdn/Samples/Blocks`:


### PR DESCRIPTION
### Description

If you follow the `README.md` instructions to set up the sniffs you get an error:

```
[~/projects/glovre-hosting/public_html] composer config repositories:extdn-phpcs vcs git@github.com:extdn/extdn-phpcs.git

  [InvalidArgumentException]
  Setting repositories:extdn-phpcs does not exist or is not supported by this command
```

I've amended the command.

### Sniff checklist

None relevant, very tiny PR