### PR TITLE
Remove repository registration from installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ repository forms an effort to come up with more advanced rulesets than there cur
 
 To install this package, go to your Magento 2 root and use the following:
 
-    composer config repositories.extdn-phpcs vcs git@github.com:extdn/extdn-phpcs.git
     composer require extdn/phpcs:dev-master
 
 Once installed, you can run PHPCS from the command-line to analyse your code `XYZ`:


### PR DESCRIPTION
As the repository is now registered with Packagist, defining the repository should not be necessary any more.