### PR TITLE
Rule: Do not use debugging statements

### DIFF
--- a/Extdn/Samples/Code/NoDebuggingStatements.php
+++ b/Extdn/Samples/Code/NoDebuggingStatements.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Foo;
+
+class Bar
+{
+    public function doSomething()
+    {
+        die('Check for this');
+    }
+
+    public function doSomethingElse()
+    {
+        var_export('test', true);
+    }
+}

--- a/Extdn/Sniffs/Code/NoDebuggingStatementsSniff.md
+++ b/Extdn/Sniffs/Code/NoDebuggingStatementsSniff.md
@@ -1,0 +1,14 @@
+# Rule: Do not keep debugging messages in your production code
+## Background
+Not everybody uses XDebug all the time. Sometimes a quick `print_r()` or `die()` is easier. However, when releasing code to production, these debugging messages
+should not be in your code. If production code still contains debugging messages it could be a sign that more is at hand.
+
+## Reasoning
+Functions like `die()`, `print_r`, `var_export` and `var_dump` are only added while debugging code. Once debugging has finished, these code segments should be
+removed.
+
+## How it works
+This rule scans the source code for strings that match debugging functions.
+
+## How to fix
+Simply remove the debugging statements from your code.

--- a/Extdn/Sniffs/Code/NoDebuggingStatementsSniff.php
+++ b/Extdn/Sniffs/Code/NoDebuggingStatementsSniff.php
@@ -15,12 +15,17 @@ class NoDebuggingStatementsSniff implements Sniff
     /**
      * @var string
      */
-    protected $message = 'Debugging statements should not be kept in production code.';
+    private $message = 'Debugging statements should not be kept in production code.';
 
     /**
      * @var int
      */
-    protected $severity = 8;
+    private $severity = 8;
+
+    /**
+     * @var string 
+     */
+    private $url = 'https://github.com/extdn/extdn-phpcs/blob/master/Extdn/Sniffs/Code/NoDebuggingStatementsSniff.md';
 
     /**
      * @inheritdoc
@@ -65,6 +70,7 @@ class NoDebuggingStatementsSniff implements Sniff
         if ($token['type'] == 'T_EXIT' && in_array($token['content'], $exitFunctions)) {
             $message = $this->message;
             $message .= sprintf(' Function "%s()" was found.', $token['content']);
+            $message .= ' See '.$this->url;
             $phpcsFile->addWarning($message, $stackPtr, $token['content']);
             return true;
         }
@@ -73,6 +79,7 @@ class NoDebuggingStatementsSniff implements Sniff
         if ($token['type'] == 'T_STRING' && in_array($token['content'], $debuggingFunctions)) {
             $message = $this->message;
             $message .= sprintf(' Function "%s()" was found.', $token['content']);
+            $message .= ' See '.$this->url;
             $phpcsFile->addWarning($message, $stackPtr, $token['content']);
             return true;
         }

--- a/Extdn/Sniffs/Code/NoDebuggingStatementsSniff.php
+++ b/Extdn/Sniffs/Code/NoDebuggingStatementsSniff.php
@@ -42,15 +42,16 @@ class NoDebuggingStatementsSniff implements Sniff
                 continue;
             }
 
-            if ($token['type'] == 'T_EXIT' && $token['content'] == 'die') {
+            $exitFunctions = ['exit', 'die'];
+            if ($token['type'] == 'T_EXIT' && in_array($token['content'], $exitFunctions)) {
                 $message = $this->message;
                 $message .= ' Function "die()" was found in the code.';
                 $phpcsFile->addWarning($message, $stackPtr, 'die');
                 continue;
             }
 
-            $debuggingStrings = ['print_r', 'var_export', 'var_dump'];
-            if ($token['type'] == 'T_STRING' && in_array($token['content'], $debuggingStrings)) {
+            $debuggingFunctions = ['print_r', 'var_export', 'var_dump'];
+            if ($token['type'] == 'T_STRING' && in_array($token['content'], $debuggingFunctions)) {
                 $message = $this->message;
                 $message .= ' Function "var_export()" was found in the code.';
                 $phpcsFile->addWarning($message, $stackPtr, 'var_export');

--- a/Extdn/Sniffs/Code/NoDebuggingStatementsSniff.php
+++ b/Extdn/Sniffs/Code/NoDebuggingStatementsSniff.php
@@ -15,7 +15,7 @@ class NoDebuggingStatementsSniff implements Sniff
     /**
      * @var string
      */
-    protected $message = 'No debugging statements should be added to production code.';
+    protected $message = 'Debugging statements should not be kept in production code.';
 
     /**
      * @var int

--- a/Extdn/Sniffs/Code/NoDebuggingStatementsSniff.php
+++ b/Extdn/Sniffs/Code/NoDebuggingStatementsSniff.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace Extdn\Sniffs\Code;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Class NoDebuggingStatementsSniff
+ * @package Extdn\Sniffs\File
+ */
+class NoDebuggingStatementsSniff implements Sniff
+{
+    /**
+     * @var string
+     */
+    protected $message = 'No debugging statements should be added to production code.';
+
+    /**
+     * @var int
+     */
+    protected $severity = 8;
+
+    /**
+     * @inheritdoc
+     */
+    public function register()
+    {
+        return [T_CLASS];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        foreach ($tokens as $token) {
+            if (!isset($token['type']) || !isset($token['content'])) {
+                continue;
+            }
+
+            if ($token['type'] == 'T_EXIT' && $token['content'] == 'die') {
+                $message = $this->message;
+                $message .= ' Function "die()" was found in the code.';
+                $phpcsFile->addWarning($message, $stackPtr, 'die');
+                continue;
+            }
+
+            $debuggingStrings = ['print_r', 'var_export', 'var_dump'];
+            if ($token['type'] == 'T_STRING' && in_array($token['content'], $debuggingStrings)) {
+                $message = $this->message;
+                $message .= ' Function "var_export()" was found in the code.';
+                $phpcsFile->addWarning($message, $stackPtr, 'var_export');
+                continue;
+            }
+        }
+    }
+}
+

--- a/Extdn/Sniffs/Code/NoDebuggingStatementsSniff.php
+++ b/Extdn/Sniffs/Code/NoDebuggingStatementsSniff.php
@@ -36,28 +36,48 @@ class NoDebuggingStatementsSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
-
-        foreach ($tokens as $token) {
-            if (!isset($token['type']) || !isset($token['content'])) {
-                continue;
+        $types = [T_EXIT, T_STRING];
+        while ($stackPtr = $phpcsFile->findNext($types, $stackPtr)) {
+            if (!$stackPtr || !isset($tokens[$stackPtr])) {
+                break;
             }
 
-            $exitFunctions = ['exit', 'die'];
-            if ($token['type'] == 'T_EXIT' && in_array($token['content'], $exitFunctions)) {
-                $message = $this->message;
-                $message .= ' Function "die()" was found in the code.';
-                $phpcsFile->addWarning($message, $stackPtr, 'die');
-                continue;
-            }
-
-            $debuggingFunctions = ['print_r', 'var_export', 'var_dump'];
-            if ($token['type'] == 'T_STRING' && in_array($token['content'], $debuggingFunctions)) {
-                $message = $this->message;
-                $message .= ' Function "var_export()" was found in the code.';
-                $phpcsFile->addWarning($message, $stackPtr, 'var_export');
-                continue;
-            }
+            $token = $tokens[$stackPtr];
+            $this->processToken($phpcsFile, $stackPtr, $token);
+            $stackPtr++;
         }
+    }
+
+    /**
+     * @param File $phpcsFile
+     * @param int $stackPtr
+     * @param array $token
+     *
+     * @return bool
+     */
+    private function processToken(File $phpcsFile, int $stackPtr, array $token): bool
+    {
+        if (!isset($token['type']) || !isset($token['content'])) {
+            return false;
+        }
+
+        $exitFunctions = ['exit', 'die'];
+        if ($token['type'] == 'T_EXIT' && in_array($token['content'], $exitFunctions)) {
+            $message = $this->message;
+            $message .= sprintf(' Function "%s()" was found.', $token['content']);
+            $phpcsFile->addWarning($message, $stackPtr, $token['content']);
+            return true;
+        }
+
+        $debuggingFunctions = ['print_r', 'var_export', 'var_dump'];
+        if ($token['type'] == 'T_STRING' && in_array($token['content'], $debuggingFunctions)) {
+            $message = $this->message;
+            $message .= sprintf(' Function "%s()" was found.', $token['content']);
+            $phpcsFile->addWarning($message, $stackPtr, $token['content']);
+            return true;
+        }
+
+        return false;
     }
 }
 

--- a/Extdn/Tests/Code/NoDebuggingStatementsUnitTest.inc
+++ b/Extdn/Tests/Code/NoDebuggingStatementsUnitTest.inc
@@ -1,0 +1,10 @@
+<?php
+namespace Extdn\Samples\Code;
+
+class NoDebuggingStatements
+{
+    public function __construct()
+    {
+        die('Whoops');
+    }
+}

--- a/Extdn/Tests/Code/NoDebuggingStatementsUnitTest.php
+++ b/Extdn/Tests/Code/NoDebuggingStatementsUnitTest.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Extdn\Tests\Code;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class NoDebuggingStatementsUnitTest extends AbstractSniffUnitTest
+{
+    /**
+     * @inheritdoc
+     */
+    public function getErrorList()
+    {
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getWarningList()
+    {
+        return [8 => 1];
+    }
+}

--- a/Extdn/Tests/Code/NoDebuggingStatementsUnitTest.php
+++ b/Extdn/Tests/Code/NoDebuggingStatementsUnitTest.php
@@ -20,6 +20,6 @@ class NoDebuggingStatementsUnitTest extends AbstractSniffUnitTest
      */
     public function getWarningList()
     {
-        return [8 => 1];
+        return [4 => 1];
     }
 }

--- a/Extdn/ruleset.xml
+++ b/Extdn/ruleset.xml
@@ -8,5 +8,6 @@
     </rule>
     <rule ref="Extdn.Blocks.SetTemplateInBlock"/>
     <rule ref="Extdn.Classes.StrictTypes"/>
+    <rule ref="Extdn.Code.NoDebuggingStatements"/>
     <rule ref="Extdn.Templates.TemplateObjectManager"/>
 </ruleset>


### PR DESCRIPTION
### Description
In a production-ready extension, there shouldn't be any functions like `die()`, `print_r()`, `var_export()` or `var_dump()`. This PR adds a new rule that checks upon this. This is a very simple straightforward PHPCS implementation.

One thing that I foresee as an issue already is that I sometimes log things away by using `var_export($x, true)`. I'm not sure if that's a lack of quality or simply a nifty feature.

### Related issues
None

### Sniff checklist
 - [X] Sniff is accompanied by unit test
 - [X] Sniff is documented using the [documentation template](docs/rule-documentation-template.md)