### PR TITLE
Deprecated parents fix

### DIFF
--- a/Extdn/Sniffs/Blocks/DeprecatedParentsSniff.php
+++ b/Extdn/Sniffs/Blocks/DeprecatedParentsSniff.php
@@ -43,7 +43,9 @@ class DeprecatedParentsSniff implements Sniff
         }
 
         // Make sure to load the file itself, so that autoloading can be skipped
-        include_once($phpcsFile->getFilename());
+        if (!class_exists($className)) {
+            include_once($phpcsFile->getFilename());
+        }
 
         $class = Reflection::getClass($className);
         $parentClass = $class->getParentClass();

--- a/Extdn/Sniffs/Blocks/DeprecatedParentsSniff.php
+++ b/Extdn/Sniffs/Blocks/DeprecatedParentsSniff.php
@@ -50,6 +50,10 @@ class DeprecatedParentsSniff implements Sniff
         $class = Reflection::getClass($className);
         $parentClass = $class->getParentClass();
 
+        if (!$parentClass) {
+            return;
+        }
+
         foreach ($this->getDeprecatedClasses() as $deprecatedClass) {
             if ($parentClass->getName() !== $deprecatedClass['class']) {
                 continue;


### PR DESCRIPTION
### Description
Bugfixes for edge cases in DeprecatedParentsSniff:

- Due to sniffs that evaluate code, a class may already be autoloaded, do not include the file in that case
- Do not throw  `PHP Fatal error:  Uncaught Error: Call to a member function getName() on boolean` if a block does not have a parent class