### PR TITLE
Add Composer package type

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Once installed, you can run PHPCS from the command-line to analyse your code `XY
     vendor/bin/phpcs --standard=./vendor/extdn/phpcs/Extdn app/code/XYZ
     vendor/bin/phpcs --standard=./vendor/extdn/phpcs/Extdn vendor/XYZ
 
+If you have a Composer Installer Plugin for PHPCS coding standards (such as https://github.com/Dealerdirect/phpcodesniffer-composer-installer) configured in the project, you can refer to this standard simply by its name:
+
+    vendor/bin/phpcs --standard=Extdn app/code/XYZ
+    vendor/bin/phpcs --standard=Extdn vendor/XYZ
+
 ## Where to contribute
 We need help in the following areas:
 - Documentation of existing EQP rules (where each EQP rule could be included in this repository its `ruleset.xml`)

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "A set of PHP_CodeSniffer rules and sniffs.",
     "homepage": "https://github.com/extdn/extdn-phpcs",
     "license": "MIT",
+    "type": "phpcodesniffer-standard",
     "authors": [
         {
             "name": "ExtDN",


### PR DESCRIPTION
### Description
Add package type to `composer.json` to allow the package to be automatically registered with PHPCS.

Please refer to https://github.com/Dealerdirect/phpcodesniffer-composer-installer/wiki/Change-%60composer.json%60-%22type%22-to-%60phpcodesniffer-standard%60 for more information.

### Related issues
None.

### Sniff checklist
N/A